### PR TITLE
sync Connection and ConnectionString

### DIFF
--- a/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
@@ -145,7 +145,8 @@ public class NpgsqlOptionsExtension : RelationalOptionsExtension
     /// <inheritdoc />
     public override RelationalOptionsExtension WithConnection(DbConnection? connection)
     {
-        var clone = (NpgsqlOptionsExtension)base.WithConnection(connection);
+        var clone = (NpgsqlOptionsExtension)base.WithConnection(connection)
+            .WithConnectionString(connection?.ConnectionString);
 
         clone.DataSource = null;
 


### PR DESCRIPTION
When both Connection and ConnectionString are not null, Connection's ConnectionString is different to ConnectionString, the ConnectionString will be used instead of the Connection's ConnectionString.

It will cause a bug, for example, I need to create database through following code:

```csharp
DbContext.Database.Migrate()
```
if DatabaseSource is Setted:

```csharp
extension.WithDataSource(dataSource);
```
 then we set AdminDatabase:

```csharp
extension.WithAdminDatabase("postgres");
```
it wont work.